### PR TITLE
spline_akima: use the right-edge curvature for the upper phantom points

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,3 +84,7 @@ target_link_libraries (xvmec vmec)
 add_executable (xnestor ${CMAKE_CURRENT_SOURCE_DIR}/src/NESTOR/nestor_main.f90)
 target_link_libraries (xnestor vmec)
 
+### unit tests
+enable_testing ()
+add_subdirectory (test/unit)
+

--- a/src/spline_akima.f
+++ b/src/spline_akima.f
@@ -78,18 +78,20 @@
       m(-1:iv+1) = (yloc(0:iv+2)-yloc(-1:iv+1))/
      >             (xloc(0:iv+2)-xloc(-1:iv+1))
 ! values for i=0, -1 and iv, iv+1 by quadratic extrapolation:
+! the right edge mirrors the left: use the right-edge curvature cr (not cl)
+! for the upper phantom points, so the interpolant is orientation-independent.
       cl = (m(2)-m(1))/(xloc(3)-xloc(1))
       bl = m(1) - cl*(xloc(2)-xloc(1))
-      cr = (m(iv-2)-m(iv-1))/(xloc(iv)-xloc(iv-2))
-      br = m(iv-2) - cr*(xloc(iv-1)-xloc(iv-2))
+      cr = (m(iv-1)-m(iv-2))/(xloc(iv)-xloc(iv-2))
+      br = m(iv-1) - cr*(xloc(iv-1)-xloc(iv))
       yloc( 0)=yloc(1)+bl*(xloc( 0)-xloc(1))+
      >                 cl*(xloc( 0)-xloc(1))**2
       yloc(-1)=yloc(1)+bl*(xloc(-1)-xloc(1))+
      >                 cl*(xloc(-1)-xloc(1))**2
       yloc(iv+1)=yloc(iv)+br*(xloc(iv+1)-xloc(iv))+
-     >                    cl*(xloc(iv+1)-xloc(iv))**2
+     >                    cr*(xloc(iv+1)-xloc(iv))**2
       yloc(iv+2)=yloc(iv)+br*(xloc(iv+2)-xloc(iv))+
-     >                    cl*(xloc(iv+2)-xloc(iv))**2
+     >                    cr*(xloc(iv+2)-xloc(iv))**2
 ! rest of linear derivatives
       m(-1) = (yloc(0)-yloc(-1))/(xloc(0)-xloc(-1))
       m( 0) = (yloc(1)-yloc( 0))/(xloc(1)-xloc( 0))

--- a/src/spline_akima_int.f
+++ b/src/spline_akima_int.f
@@ -50,18 +50,20 @@
      >               dxloc(-1:iv+1)
 !    >               (xloc(0:iv+2)-xloc(-1:iv+1))
 ! values for i=0, -1 and iv, iv+1 by quadratic extrapolation:
+! the right edge mirrors the left: use the right-edge curvature cr (not cl)
+! for the upper phantom points, so the interpolant is orientation-independent.
       cl = (m(2)-m(1))/(xloc(3)-xloc(1))
       bl = m(1) - cl*(xloc(2)-xloc(1))
-      cr = (m(iv-2)-m(iv-1))/(xloc(iv)-xloc(iv-2))
-      br = m(iv-2) - cr*(xloc(iv-1)-xloc(iv-2))
+      cr = (m(iv-1)-m(iv-2))/(xloc(iv)-xloc(iv-2))
+      br = m(iv-1) - cr*(xloc(iv-1)-xloc(iv))
       yloc( 0)=yloc(1)+bl*(xloc( 0)-xloc(1))+
      >               cl*(xloc( 0)-xloc(1))**2
       yloc(-1)=yloc(1)+bl*(xloc(-1)-xloc(1))+
      >               cl*(xloc(-1)-xloc(1))**2
       yloc(iv+1)=yloc(iv)+br*(xloc(iv+1)-xloc(iv))+
-     >               cl*(xloc(iv+1)-xloc(iv))**2
+     >               cr*(xloc(iv+1)-xloc(iv))**2
       yloc(iv+2)=yloc(iv)+br*(xloc(iv+2)-xloc(iv))+
-     >               cl*(xloc(iv+2)-xloc(iv))**2
+     >               cr*(xloc(iv+2)-xloc(iv))**2
 ! rest of linear derivatives
       m(-1) = (yloc(0)-yloc(-1))/(xloc(0)-xloc(-1))
       m( 0) = (yloc(1)-yloc( 0))/(xloc(1)-xloc( 0))

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -1,0 +1,12 @@
+# Unit tests for individual numerical routines.
+#
+# Standalone targets that compile only the sources under test, so they do not
+# depend on the full vmec library or its NetCDF/FFTW/LAPACK link.
+
+add_executable (test_spline_akima
+  ${CMAKE_CURRENT_SOURCE_DIR}/test_spline_akima.f90
+  ${CMAKE_SOURCE_DIR}/src/data/stel_kinds.f90
+  ${CMAKE_SOURCE_DIR}/src/spline_akima.f)
+set_target_properties (test_spline_akima PROPERTIES
+  Fortran_MODULE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/modules)
+add_test (NAME spline_akima_reflection_symmetry COMMAND test_spline_akima)

--- a/test/unit/test_spline_akima.f90
+++ b/test/unit/test_spline_akima.f90
@@ -1,0 +1,47 @@
+!> \file
+!> \brief Unit test for the Akima spline right-edge curvature.
+!>
+!> The corrected right edge mirrors the left edge, so interpolating the mirror
+!> image of a dataset at mirrored query points reproduces the original
+!> interpolant. This reflection symmetry holds only when the right-edge phantom
+!> points use the right-edge curvature cr; the earlier code reused the left
+!> curvature cl on the right edge, which broke the symmetry. The test therefore
+!> fails against the pre-fix routine and passes against the fixed one.
+program test_spline_akima
+  use stel_kinds, only: rprec
+  implicit none
+
+  integer, parameter :: n = 5
+  real(rprec), parameter :: tol = 1.0e-12_rprec
+
+  real(rprec) :: knots(n)  = (/ 0.0_rprec, 0.2_rprec, 0.45_rprec, &
+                                0.7_rprec, 1.0_rprec /)
+  real(rprec) :: values(n) = (/ 0.3_rprec, 0.7_rprec, 0.55_rprec, &
+                                0.9_rprec, 0.1_rprec /)
+  real(rprec) :: mirrored_knots(n), mirrored_values(n)
+  real(rprec) :: xq(5) = (/ 0.05_rprec, 0.18_rprec, 0.50_rprec, &
+                            0.83_rprec, 0.96_rprec /)
+
+  integer :: i, iflag
+  real(rprec) :: forward, reflected, max_asymmetry
+
+  ! mirror about the knot span [0, 1]: reverse the nodes and map x -> 1 - x
+  do i = 1, n
+    mirrored_knots(i)  = 1.0_rprec - knots(n + 1 - i)
+    mirrored_values(i) = values(n + 1 - i)
+  end do
+
+  max_asymmetry = 0.0_rprec
+  do i = 1, size(xq)
+    call spline_akima(xq(i),            forward,   knots,          values,          n, iflag)
+    call spline_akima(1.0_rprec-xq(i),  reflected, mirrored_knots, mirrored_values, n, iflag)
+    max_asymmetry = max(max_asymmetry, abs(forward - reflected))
+  end do
+
+  write (*, '(A, ES12.4)') 'max reflection asymmetry = ', max_asymmetry
+  if (max_asymmetry > tol) then
+    write (*, '(A)') 'FAIL: Akima interpolant is not reflection-symmetric'
+    error stop 1
+  end if
+  write (*, '(A)') 'PASS: Akima interpolant is reflection-symmetric'
+end program test_spline_akima


### PR DESCRIPTION
## Problem

`spline_akima.f` and `spline_akima_int.f` extend the data with two phantom points at each end by quadratic extrapolation. The left edge uses its own curvature `cl` and slope `bl`; the right edge is meant to mirror it with `cr`/`br`. Two things were off:

- `cr`/`br` were formed in the reverse order from the left edge,

  ```fortran
  cr = (m(iv-2)-m(iv-1))/(xloc(iv)-xloc(iv-2))
  br = m(iv-2) - cr*(xloc(iv-1)-xloc(iv-2))
  ```

  so `cr` carried the wrong sign and `br` the wrong base point; the `cr` that was computed was never actually used.
- the upper phantom points `yloc(iv+1)` / `yloc(iv+2)` were extrapolated with the left-edge curvature `cl` rather than `cr`.

The right boundary therefore used the wrong curvature, and the interpolant depended on the orientation of the data: interpolating the mirror image of a dataset at mirrored query points did not reproduce the original interpolant.

## Fix

Form `cr`/`br` as the mirror of the left edge and use `cr` for the upper phantom points:

```fortran
cr = (m(iv-1)-m(iv-2))/(xloc(iv)-xloc(iv-2))
br = m(iv-1) - cr*(xloc(iv-1)-xloc(iv))
...
yloc(iv+1) = yloc(iv) + br*(xloc(iv+1)-xloc(iv)) + cr*(xloc(iv+1)-xloc(iv))**2
yloc(iv+2) = yloc(iv) + br*(xloc(iv+2)-xloc(iv)) + cr*(xloc(iv+2)-xloc(iv))**2
```

The secant `m(iv-1)` equals the mean slope of the right-edge quadratic over `[xloc(iv-1), xloc(iv)]`, which gives `br = m(iv-1) - cr*(xloc(iv-1)-xloc(iv))`, the mirror of `bl = m(1) - cl*(xloc(2)-xloc(1))`. `spline_akima_int.f` shares the construction and gets the same change.

## Test

`test/unit/test_spline_akima.f90`, wired via CTest as `spline_akima_reflection_symmetry`, interpolates a dataset and its mirror image about the knot span and checks that they agree at mirrored query points. The maximum reflection asymmetry is `1.5e-1` against the previous right edge and `2.2e-16` with the fix, so the test fails before this change and passes after. The target is standalone (it compiles only `stel_kinds` and `spline_akima.f`), so it does not depend on the full library link.
