### PR TITLE
Remove the lasym output doubling that compensated the old fixaray norm

### DIFF
--- a/src/funct3d.f90
+++ b/src/funct3d.f90
@@ -426,13 +426,10 @@ SUBROUTINE funct3d (ier_flag)
      ! COMPUTE MHD FORCES ON INTEGER-MESH
      CALL forces
 
-     ! SYMMETRIZE FORCES (in u-v space): NOTE - gc IS SMALL BY FACTOR 2 IF lasym=T
+     ! SYMMETRIZE FORCES (in u-v space)
      IF (lasym) THEN
         CALL symforce (armn, brmn, crmn, azmn, bzmn, czmn,   blmn,   clmn,   rcon,   zcon, &
                          r1,   ru,   rv,   z1,   zu,   zv, extra3, extra4, extra1, extra2   )
-
-        ! NOT NECESSARY (EVEN THOUGH CORRECT) --> why?
-        !gc = 2*gc
      END IF
 
      ! FOURIER-TRANSFORM MHD FORCES TO (M,N)-SPACE
@@ -450,14 +447,6 @@ SUBROUTINE funct3d (ier_flag)
                       extra3, extra4, extra1, extra2)
         call tomnspa_con(gc_con, brmn_con, bzmn_con, extra1, extra2)
      end if
-
-     IF (lasym) THEN
-       ! NOT NECESSARY (EVEN THOUGH CORRECT) --> why?
-       !gc     = 2*gc
-       !gc_con = 2*gc_con
-     end if
-
-
 
      ! COMPUTE FORCE RESIDUALS (RAW AND PRECONDITIONED)
      gc     = gc     * scalxc    !!IS THIS CORRECT: SPH010214?

--- a/src/jxbforce.f90
+++ b/src/jxbforce.f90
@@ -211,9 +211,6 @@ SUBROUTINE jxbforce(bsupu, bsupv, bsubu, bsubv, bsubsh, &
            bsubvmn1 = 0
            bsubvmn2 = 0
            IF (lasym) THEN
-              ! SPH012314 in FixAray
-              dnorm1 = 2*dnorm1
-
               bsubsmn3 = 0
               bsubsmn4 = 0
               bsubumn3 = 0

--- a/src/wrout.f90
+++ b/src/wrout.f90
@@ -529,8 +529,6 @@ SUBROUTINE wrout(bsq, gsqrt, bsubu, bsubv, bsubs, bsupv, bsupu, rzl_array, gc_ar
   tmult = p5/r0scale**2
   !SPH: FIXED THIS 03-05-07 TO CALL symmetrization routine
   IF (lasym) THEN
-     ! Changed integration norm in fixaray, SPH012314
-     tmult = 2*tmult
      bsubs(1,:) = 0
      CALL symoutput (bsq,   gsqrt,  bsubu,  bsubv,  bsupu,   &
                      bsupv,  bsubs,                          &


### PR DESCRIPTION
Fixes #4.

`wrout.f90` and `jxbforce.f90` doubled the forward-transform normalization for `lasym = T` to compensate the halved `dnorm` that `fixaray` used to set for that case (`SPH012314`). That branch of `dnorm` was removed in bd2d0f3 and 05c81f6, so the two doublings are the only remaining trace of it and every lasym output built through them came out at twice its value, or four times where jxbforce and wrout both applied it. The matching removal was made in PARVMEC in 82f401b.

The comment at the symforce call in `funct3d.f90` described the halved norm as well and is dropped together with the two commented-out `gc = 2*gc` blocks it referred to.

Checked with `input.cth_like_fixed_bdy` run with `LASYM = F` and `LASYM = T`: after the change every wout variable agrees between the two runs to 1e-10 relative, and all asymmetric arrays are zero to machine precision.
