### PR TITLE
Carry signgs in chi

### DIFF
--- a/src/eqfor.f90
+++ b/src/eqfor.f90
@@ -160,7 +160,7 @@ SUBROUTINE eqfor(br, bz, bsubu, bsubv, tau, rzl_array, ier_flag)
      phi1(i) = phi1(i-1) + hs*phip(i)
      chi1(i) = chi1(i-1) + hs*(phip(i)*iotas(i))
   END DO
-  chi = twopi*chi1
+  chi = twopi*signgs*chi1 ! same sign convention as phi (fileout) and the phipf, chipf written by wrout
 
 
 


### PR DESCRIPTION
Fixes #5.

`chi` is accumulated in `eqfor.f90` without `signgs`, while `phi` (fileout.f90:61) and the `phipf` and `chipf` written by wrout all carry it, so the file held `chi = -∫ iota dphi`. The factor is added where `chi` is formed from `chi1`.

Checked with `input.cth_like_fixed_bdy`: `chi(ns)` changes from +0.040086 to -0.040086, the value of `Σ iotas(js) phipf(js) hs`, and no other wout variable changes.
