### PR TITLE
Extrapolate chipf onto the axis and the boundary like iotaf

### DIFF
--- a/src/add_fluxes.f90
+++ b/src/add_fluxes.f90
@@ -63,8 +63,9 @@ SUBROUTINE add_fluxes(overg, bsupu, bsupv)
 
   ! half-grid to full-grid for chi-prime and iota below
 
+  chipf(1)     = c1p5*chips(2)  - cp5*chips(3)
   chipf(2:ns1) = (chips(2:ns1) + chips(3:ns1+1))/2.0_dp
-  chipf(ns)    = 2.0_dp*chips(ns)-chips(ns1)
+  chipf(ns)    = c1p5*chips(ns) - cp5*chips(ns1)
 
   ! Do not compute iota too near origin
   iotaf(1)  = c1p5*iotas(2) - cp5*iotas(3)     !zero gradient near axis


### PR DESCRIPTION
Fixes #6.

`add_fluxes.f90` fills `chipf` on the interior and at the edge only, so `chipf(1)` reaches the wout as zero while `iotaf(1)` and `phipf(1)` are extrapolated to the axis. Both ends now use the rule `iotaf` uses two lines below, which is the form PARVMEC `add_fluxes.f90:153-155` has carried since 2016 (`chipf(1) = c1p5*chips(2) - p5*chips(3)`, `chipf(ns) = c1p5*chips(ns) - p5*chips(ns1)`).

Checked with `input.cth_like_fixed_bdy`: `chipf(1)` changes from 0 to -0.043643 and `chipf(ns)` from -0.028252 to -0.029128; both equal `iotaf*phipf` at their surface afterwards, as every interior point already did. No other wout variable changes. `chipf` enters `equif` only, which is a diagnostic, so the equilibrium is unchanged.
