### PR TITLE
Initialize the full-mesh bsubs in jxbforce

### DIFF
--- a/src/jxbforce.f90
+++ b/src/jxbforce.f90
@@ -110,6 +110,9 @@ SUBROUTINE jxbforce(bsupu, bsupv, bsubu, bsubv, bsubsh, &
    ! K = CURL(B) is the "effective" current (=J for isotropic pressure)
    ! Compute u (=theta), v (=zeta) derivatives of B sub s
 
+  ! Only js = 2..ns-1 are filled below, but every row is read in the radial loop.
+  bsubs = 0
+
   ! fixup input coming from bss: zero terms past magnetic axis
   ! NOTE: FIXME: This is actually the target array for the interpolation to the half-grid !!!
   ! TODO: This should probably be `bsubsh(1,:) = 0` instead !!!


### PR DESCRIPTION
Fixes #8.

The local full-mesh `bsubs` in jxbforce is filled for `js = 2..ns-1` only, but the radial loop reads row `ns` in its last pass (`bs1=>bsubs(js,:)` for lasym, `bsubs_s(:) = bsubs(js,:)` otherwise) and Fourier-transforms it. The array is now zeroed on entry.

Rows `ns` of `bsubsu`, `bsubsv`, `bsubuv` and `bsubvu` are never consumed, so the wout and jxbout files are unchanged bit for bit on `input.cth_like_fixed_bdy` in both symmetry modes. Built with `-fcheck=all -finit-real=snan -ffpe-trap=invalid,zero,overflow`, the runs that used to stop at jxbforce.f90:233 (symmetric) and fsym_fft.f90:52 (lasym) now terminate normally.
