### PR TITLE
Keep rmaga inside rzl_array for lasym with ntor = 0

### DIFF
--- a/src/eqfor.f90
+++ b/src/eqfor.f90
@@ -74,7 +74,7 @@ SUBROUTINE eqfor(br, bz, bsubu, bsubv, tau, rzl_array, ier_flag)
     IF (rcs .gt. 0) THEN
       rmaga => rzl_array(1,:,0,rcs)
     ELSE
-      ! ntor = 0: there is no cos(mu)sin(nv) basis type, so rcs == 0 would point outside rzl_array
+      ! ntor = 0: the cos(mu)sin(nv) basis type does not exist (rcs == 0)
       ALLOCATE(axis_zero(ntor+1))
       axis_zero = 0
       rmaga => axis_zero

--- a/src/eqfor.f90
+++ b/src/eqfor.f90
@@ -62,6 +62,7 @@ SUBROUTINE eqfor(br, bz, bsubu, bsubv, tau, rzl_array, ier_flag)
      zmax, zmin, yr1u, yz1u, waist(2), height(2)
   REAL(rprec) d_of_kappa, loc_jpar_perp, loc_jparPs_perp
   REAL(rprec), DIMENSION(:), ALLOCATABLE :: rax_symm, zax_symm, rax_asym, zax_asym
+  REAL(rprec), DIMENSION(:), ALLOCATABLE, TARGET :: axis_zero
 
 
   ! POINTER ASSOCIATIONS
@@ -70,7 +71,14 @@ SUBROUTINE eqfor(br, bz, bsubu, bsubv, tau, rzl_array, ier_flag)
   rmncc => rzl_array(:,:,:,rcc)
   zmnsc => rzl_array(:,:,:,zsc+ntmax)
   IF (lasym) THEN
-    rmaga => rzl_array(1,:,0,rcs)
+    IF (rcs .gt. 0) THEN
+      rmaga => rzl_array(1,:,0,rcs)
+    ELSE
+      ! ntor = 0: there is no cos(mu)sin(nv) basis type, so rcs == 0 would point outside rzl_array
+      ALLOCATE(axis_zero(ntor+1))
+      axis_zero = 0
+      rmaga => axis_zero
+    END IF
     zmaga => rzl_array(1,:,0,zcc+ntmax)
   END IF
 


### PR DESCRIPTION
Fixes #9.

For `LASYM = T` with `NTOR = 0`, read_indata leaves `rcs = 0` because the cos(mu)sin(nv) basis type does not exist, and `rmaga => rzl_array(1,:,0,rcs)` in eqfor.f90 then points at type index 0 of a dimension declared `1:3*ntmax`. `rmaga` is now associated only when `rcs > 0` and otherwise points at a zero array of the same extent, which is the value the missing basis type contributes.

Checked with `input.up_down_asymmetric_tokamak` (VMEC++ test data) and a symmetric tokamak boundary run with `LASYM = T`: the wout files are unchanged bit for bit, and a build with `-fcheck=all` that used to stop at eqfor.f90:73 with `Index '0' of dimension 4 of array 'rzl_array' outside of expected range (1:6)` now terminates normally.
