### PR TITLE
Initialize potvac and the aux_f profile arrays before they reach the wout file

### DIFF
--- a/src/NESTOR/data/vacmod.f90
+++ b/src/NESTOR/data/vacmod.f90
@@ -177,6 +177,9 @@ subroutine allocate_nestor
             raxis_nestor(nv), zaxis_nestor(nv), stat=istat1)
   IF (istat1.ne.0) STOP 'allocation error #3 in allocate_nestor'
 
+  ! The solver fills the first mnpd2 entries only; the whole array is written to the wout file.
+  potvac = 0
+
   allocate(m_map_wrt(mnpd2), n_map_wrt(mnpd2), stat=istat1)
   if (istat1 .ne. 0) then
      stop 'could not allocate m_map, n_map'

--- a/src/data/vmec_input.f90
+++ b/src/data/vmec_input.f90
@@ -359,6 +359,9 @@ SUBROUTINE read_indata_namelist (iunit, istat)
   am_aux_s(:) = -1
   ac_aux_s(:) = -1
   ai_aux_s(:) = -1
+  am_aux_f(:) = 0
+  ac_aux_f(:) = 0
+  ai_aux_f(:) = 0
 
   ! by default, dump first two iterations
   iter2_to_dump(:) = 0


### PR DESCRIPTION
Fixes #10.

`potvac` is allocated with `2*mnpd` entries for every run while the solver fills `mnpd2` of them, which is `mnpd` for `lasym = F`; wrout writes the whole array and freeb_data reads the upper half as `potcos`. The array is now zeroed after the allocation. The three `_aux_f` profile arrays had no default next to the `_aux_s = -1` defaults and were written to the wout from static memory; they now default to zero.

Checked with `input.cth_like_free_bdy` (VMEC++ test data): the upper half of `potvac` in the wout, which held values up to 4e294 before, is zero; the lower half and every other wout variable are unchanged bit for bit. Built with `-finit-real=snan`, the `_aux_f` arrays in the wout are zero instead of NaN.
