### PR TITLE
Take bmin and bmax over every stored poloidal line

### DIFF
--- a/src/allocate_ns.f90
+++ b/src/allocate_ns.f90
@@ -45,7 +45,7 @@ SUBROUTINE allocate_ns (linterp, neqs_old)
 
   ALLOCATE( ard(nsp1,2),arm(nsp1,2),brd(nsp1,2),brm(nsp1,2),  &
             azd(nsp1,2),azm(nsp1,2),bzd(nsp1,2),bzm(nsp1,2), &
-            sm(ns), sp(0:ns), bmin(ntheta2,ns), bmax(ntheta2,ns), stat=istat1)
+            sm(ns), sp(0:ns), bmin(ntheta3,ns), bmax(ntheta3,ns), stat=istat1)
   IF (istat1.ne.0) STOP 'allocation error #6 in allocate_ns'
 
   ALLOCATE( iotaf(nsp1), crd(nsp1), mass(ns), phi(ns), presf(ns),   &

--- a/src/eqfor.f90
+++ b/src/eqfor.f90
@@ -390,7 +390,8 @@ SUBROUTINE eqfor(br, bz, bsubu, bsubv, tau, rzl_array, ier_flag)
 
   DO js = 2, ns
      modb(:nznt) = SQRT(c2p0*(bsq(js:nrzt:ns) - pres(js)))
-     CALL bextrema (modb, bmin(1,js), bmax(1,js), nzeta, ntheta2)
+     ! one poloidal line per stored theta point: ntheta2 for stellarator symmetry, ntheta1 for lasym
+     CALL bextrema (modb, bmin(1,js), bmax(1,js), nzeta, ntheta3)
   END DO
 
   WRITE (nthreed, 75) bmin(1,ns), bmax(1,ns), bmin(ntheta2,ns), bmax(ntheta2,ns)


### PR DESCRIPTION
Fixes #17.

`bmin` and `bmax` are allocated with `ntheta3` poloidal lines and `bextrema` is called over `ntheta3`, so a lasym run keeps the |B| extrema along every stored poloidal line instead of the first half only. `ntheta3 = ntheta2` for a stellarator-symmetric run, so nothing changes there; the threed1 lines at u = 0 and u = pi keep their indices in both cases.

Checked with `input.cth_like_fixed_bdy` run with `LASYM = F` and `LASYM = T`: the four printed extrema agree between the two runs and with the build before the change. On `input.cth_like_fixed_bdy_asym` (VMEC++ test data) the boundary `bmax` over the stored lines rises from 0.73987 to 0.78388, the value the wout `bmnc`, `bmns` give on the full grid.
