### PR TITLE
Scan every toroidal plane for the axis guess of a lasym run

### DIFF
--- a/src/guess_axis.f90
+++ b/src/guess_axis.f90
@@ -69,7 +69,7 @@ SUBROUTINE guess_axis(r1, z1, ru0, zu0)
 
   ns12 = (ns+1)/2
 
-  planes: DO iv = 1, nzeta/2+1
+  planes: DO iv = 1, ivmax
 
      r1b(iv,:ntheta3) = r1(ns,iv,:,0) + r1(ns,iv,:,1)
      z1b(iv,:ntheta3) = z1(ns,iv,:,0) + z1(ns,iv,:,1)


### PR DESCRIPTION
Fixes #21.

`guess_axis` already computes the number of planes it has to scan,

```fortran
if (.not.lasym) then
  ivmax = nzeta/2+1
else
  ivmax = nzeta
end if
```

but the plane loop runs to `nzeta/2+1` regardless, so for `lasym = T` the entries `rcom(nzeta/2+2:nzeta)` and `zcom(nzeta/2+2:nzeta)` reach the axis Fourier transform unassigned. The loop now uses `ivmax`, which is the same bound as before for `lasym = F` and covers the whole toroidal range otherwise. PARVMEC `guess_axis.f:132` scans all `nzeta` planes for the same reason.

Checked with `input.cma` run with `LASYM = F` and `LASYM = T`, the latter with every asymmetric coefficient left at zero. Both trigger the axis reguess. Before this change the asymmetric run stops with `The jacobian was non-definite!` at `ns = 25`; after it, both runs terminate normally at `ns = 51` and their wout files agree to the 1e-6 force tolerance of the case. `wout_cma.nc`, `wout_solovev.nc` and `wout_cth_like_fixed_bdy.nc` are unchanged bit for bit, since `ivmax` is `nzeta/2+1` in the symmetric branch.


VMEC++ carries the same half-range loop at `guess_magnetic_axis.cc:382`, fixed in proximafusion/vmecpp#787.
