### PR TITLE
Carry B_s to the wout file on the full radial mesh

### DIFF
--- a/src/jxbforce.f90
+++ b/src/jxbforce.f90
@@ -7,7 +7,8 @@
 !> @param bsupv contravariant component of magnetic field \f$B^\zeta\f$
 !> @param bsubu covariant component of magnetic field \f$B_\theta\f$
 !> @param bsubv covariant component of magnetic field \f$B_\zeta\f$
-!> @param bsubsh covariant component of magnetic field \f$B_s\f$ on half grid from bss()
+!> @param bsubsh covariant component of magnetic field \f$B_s\f$: on the half grid
+!>        from bss() on entry, on the full grid on exit
 !> @param bsubsu tangential derivate of covariant component of magnetic field \f$\partial B_s / \partial \theta\f$ (?)
 !> @param bsubsv tangential derivate of covariant component of magnetic field \f$\partial B_s / \partial \zeta\f$  (?)
 !> @param gsqrt Jacobian \f$\sqrt{g}\f$
@@ -33,7 +34,7 @@ SUBROUTINE jxbforce(bsupu, bsupv, bsubu, bsubv, bsubsh, &
   REAL(rprec), DIMENSION(ns,nznt), INTENT(in) :: bsupv
   REAL(rprec), DIMENSION(ns,nznt,0:1), TARGET, INTENT(inout) :: bsubu
   REAL(rprec), DIMENSION(ns,nznt,0:1), TARGET, INTENT(inout) :: bsubv
-  REAL(rprec), DIMENSION(ns,nznt), INTENT(in)  :: bsubsh
+  REAL(rprec), DIMENSION(ns,nznt), INTENT(inout) :: bsubsh
   REAL(rprec), DIMENSION(ns,nznt,0:1) :: bsubsu
   REAL(rprec), DIMENSION(ns,nznt,0:1) :: bsubsv
   REAL(rprec), DIMENSION(ns,nznt), INTENT(in) :: gsqrt
@@ -520,6 +521,10 @@ SUBROUTINE jxbforce(bsupu, bsupv, bsubu, bsubv, bsubsh, &
   bsubs(1,:)  = 2*bsubs(2,:)  - bsubs(3,:)
   !bsubs(ns,:) = 2*bsubs(ns,:) - bsubs(ns-1,:) ! TODO: from ns, ns-1 to ns ???
   bsubs(ns,:) = 2*bsubs(ns-1,:) - bsubs(ns-2,:)
+
+  ! Return the full-mesh B_s to the caller: wrout transforms this array into
+  ! bsubsmns, which the wout file declares on the full mesh.
+  bsubsh = bsubs
 
 
 

--- a/src/jxbforce.f90
+++ b/src/jxbforce.f90
@@ -519,8 +519,9 @@ SUBROUTINE jxbforce(bsupu, bsupv, bsubu, bsubv, bsubsh, &
 
   ! Compute end point values for bsubs
   bsubs(1,:)  = 2*bsubs(2,:)  - bsubs(3,:)
-  !bsubs(ns,:) = 2*bsubs(ns,:) - bsubs(ns-1,:) ! TODO: from ns, ns-1 to ns ???
-  bsubs(ns,:) = 2*bsubs(ns-1,:) - bsubs(ns-2,:)
+  ! The outermost half point sits between bsubs(ns-1) and the boundary, so
+  ! the boundary value follows from it and one full-mesh point.
+  bsubs(ns,:) = 2*bsubsh(ns,:) - bsubs(ns-1,:)
 
   ! Return the full-mesh B_s to the caller: wrout transforms this array into
   ! bsubsmns, which the wout file declares on the full mesh.

--- a/src/read_wout_mod.f
+++ b/src/read_wout_mod.f
@@ -727,8 +727,8 @@ C-----------------------------------------------
 !     Computes current harmonics for currXmn == sqrt(g)*JsupX, X = u,v
 !     [Corrected above "JsubX" to "JsupX", JDH 2010-08-16]
 
-!     NOTE: bsub(s,u,v)mn are on HALF radial grid
-!          (in earlier versions, bsubsmn was on FULL radial grid)
+!     NOTE: bsub(u,v)mn are on the HALF radial grid, bsubsmn on the FULL one,
+!          as in ORNL-Fusion/LIBSTELL read_wout_mod.f90
 
 !
       ohs = (ns_i-1)
@@ -744,8 +744,7 @@ C-----------------------------------------------
 
       DO js = 2, ns_i-1
          WHERE (MOD(INT(xm_nyq_i),2) .EQ. 1)
-            t1 = 0.5_dp*(shalf(js+1)*bsubsmns_i(:,js+1) +
-     &                   shalf(js)  *bsubsmns_i(:,js)) /sfull(js)
+            t1 = bsubsmns_i(:,js)
             bu0 = bsubumnc_i(:,js  )/shalf(js)
             bu1 = bsubumnc_i(:,js+1)/shalf(js+1)
             t2 = ohs*(bu1-bu0)*sfull(js)+0.25_dp*(bu0+bu1)/sfull(js)
@@ -753,7 +752,7 @@ C-----------------------------------------------
             bv1 = bsubvmnc_i(:,js+1)/shalf(js+1)
             t3 = ohs*(bv1-bv0)*sfull(js)+0.25_dp*(bv0+bv1)/sfull(js)
          ELSEWHERE
-            t1 = 0.5_dp*(bsubsmns_i(:,js+1)+bsubsmns_i(:,js))
+            t1 = bsubsmns_i(:,js)
             t2 = ohs*(bsubumnc_i(:,js+1)-bsubumnc_i(:,js))
             t3 = ohs*(bsubvmnc_i(:,js+1)-bsubvmnc_i(:,js))
          ENDWHERE
@@ -783,8 +782,7 @@ C-----------------------------------------------
 
       DO js = 2, ns_i-1
          WHERE (MOD(INT(xm_nyq_i),2) .EQ. 1)
-            t1 = 0.5_dp*(shalf(js+1)*bsubsmnc_i(:,js+1)
-     &          +         shalf(js)  *bsubsmnc_i(:,js)) / sfull(js)
+            t1 = bsubsmnc_i(:,js)
             bu0 = bsubumns_i(:,js  )/shalf(js+1)
             bu1 = bsubumns_i(:,js+1)/shalf(js+1)
             t2 = ohs*(bu1-bu0)*sfull(js) + 0.25_dp*(bu0+bu1)/sfull(js)
@@ -792,7 +790,7 @@ C-----------------------------------------------
             bv1 = bsubvmns_i(:,js+1)/shalf(js+1)
             t3 = ohs*(bv1-bv0)*sfull(js)+0.25_dp*(bv0+bv1)/sfull(js)
          ELSEWHERE
-            t1 = 0.5_dp*(bsubsmnc_i(:,js+1) + bsubsmnc_i(:,js))
+            t1 = bsubsmnc_i(:,js)
             t2 = ohs*(bsubumns_i(:,js+1)-bsubumns_i(:,js))
             t3 = ohs*(bsubvmns_i(:,js+1)-bsubvmns_i(:,js))
          END WHERE

--- a/src/wrout.f90
+++ b/src/wrout.f90
@@ -602,10 +602,7 @@ SUBROUTINE wrout(bsq, gsqrt, bsubu, bsubv, bsubs, bsupv, bsupu, rzl_array, gc_ar
   bsubumnc(:,1) = 0
   bsubvmnc(:,1) = 0
 
-  ! NOTE: This assumes that bsubs (from which bsubsmns is computed) is on the full grid.
-  ! However, since crmn_o is passed as bsubs in fileout(),
-  ! HERE, bsubs is ACTUALLY on the HALF-grid !!! WTF ???
-  ! (The full-grid bsubs array is a LOCAL variable in jxbforce().)
+  ! bsubs is on the full grid here: jxbforce puts it there.
   bsubsmns(:,1) = 2*bsubsmns(:,2) - bsubsmns(:,3) ! extrapolation on full grid
 
   bsupumnc(:,1) = 0


### PR DESCRIPTION
Fixes #22.

`jxbforce` builds `B_s` on the full radial mesh in a local array and drops it at `RETURN`, so `wrout` receives the half-grid array that `bss` produced, applies a full-mesh endpoint rule to it and writes it as `!Full mesh`. `bsubsh` becomes `INTENT(inout)` and carries the full-mesh values back, which is what PARVMEC `jxbforce.f:33` does. The note at wrout.f90:603 that recorded the mismatch goes with it.

`Compute_Currents` then has to read `bsubsmn` on the full mesh rather than averaging two half-grid surfaces into `t1`. ORNL-Fusion/LIBSTELL `read_wout_mod.f90`, the copy PARVMEC links against, makes the same four substitutions.

Checked against the PARVMEC wout files for `input.solovev`, `input.cma` and `input.cth_like_fixed_bdy`, as the largest difference over the array relative to its maximum:

| | `bsubsmns` | `currumnc` | `currvmnc` |
|---|---|---|---|
| `solovev` | 8.0e-3 -> 9.4e-6 | 1.5e-10 -> 1.5e-10 | 4.2e-4 -> 2.5e-11 |
| `cma` | 2.5e-1 -> 5.1e-3 | 1.0e+0 -> 1.5e-2 | 9.8e-1 -> 2.6e-2 |
| `cth_like_fixed_bdy` | 2.5e-1 -> 2.2e-4 | 8.9e-1 -> 2.1e-6 | 5.1e-1 -> 2.5e-6 |

The boundary value is the second commit. PARVMEC reads `bsubs(ns,:)` on the right-hand side of its own edge rule, which is the half-grid value still sitting in the array it shares with the caller; here that value is `bsubsh(ns,:)`, so the outermost half point can be used directly instead of extrapolating from two full-mesh points. The largest disagreement with PARVMEC on the boundary surface goes from 9.4e-6 to 7.2e-13 for `solovev` and from 1.5e-3 to 7.0e-7 for `cth_like_fixed_bdy`, level with every interior surface. `Compute_Currents` runs from 2 to ns-1 and extrapolates the ends, so it never reads that row and the currents are unchanged. The `cma` residuals are larger because that pair of runs converged to slightly different states: `niter` differs by 7 percent and `bmnc` by 3e-4 independently of this change.

`lbsubs = T` now reaches the wout, since the correction is applied to the array the caller keeps.


VMEC++ writes the half-grid values under the name `bsubsmns`, to match this code, and publishes the full-grid transform separately as `bsubsmns_full`; the note at `output_quantities.cc:5159` records the mismatch with the wout file's own declaration and leaves it open. After this change educational_VMEC and PARVMEC agree on that variable.

