### PR TITLE
Take bu0 at its own half-grid surface in the asymmetric current harmonics

### DIFF
--- a/src/read_wout_mod.f
+++ b/src/read_wout_mod.f
@@ -785,7 +785,7 @@ C-----------------------------------------------
          WHERE (MOD(INT(xm_nyq_i),2) .EQ. 1)
             t1 = 0.5_dp*(shalf(js+1)*bsubsmnc_i(:,js+1)
      &          +         shalf(js)  *bsubsmnc_i(:,js)) / sfull(js)
-            bu0 = bsubumns_i(:,js  )/shalf(js+1)
+            bu0 = bsubumns_i(:,js  )/shalf(js)
             bu1 = bsubumns_i(:,js+1)/shalf(js+1)
             t2 = ohs*(bu1-bu0)*sfull(js) + 0.25_dp*(bu0+bu1)/sfull(js)
             bv0 = bsubvmns_i(:,js  )/shalf(js)


### PR DESCRIPTION
Fixes #23.

`bu0` is the covariant `B_theta` harmonic at surface `js`, so it divides by `shalf(js)`. `bv0` on the next line and `bu0` in the stellarator-symmetric branch above already do; only the asymmetric `bu0` used `shalf(js+1)`. ORNL-Fusion/LIBSTELL `read_wout_mod.f90` carries `shalf(js)` here.

Checked with `input.cth_like_fixed_bdy_asym` (VMEC++ test data) built with and without this one index: `currvmns` in the wout changes by 0.72 of its maximum, and every other variable in the file is unchanged bit for bit. `bu0` enters `t2`, which enters only `currvmns`, so nothing else can move. A stellarator-symmetric run does not reach this branch.


VMEC++ takes the inner surface here too, at `output_quantities.cc:5498`.
