### PR TITLE
Orient a lasym boundary by its m=1 determinant and rotate it for the flip

### DIFF
--- a/src/readin.f90
+++ b/src/readin.f90
@@ -22,6 +22,7 @@
   INTEGER :: n, iunit, ier_flag_init, i, ni, m, nsmin, mj, isgn, ioff, joff
   REAL(rprec), DIMENSION(:,:), POINTER :: rbcc, rbss, rbcs, rbsc, zbcs, zbsc, zbcc, zbss
   REAL(rprec) :: rtest, ztest, tzc, trc, delta
+  REAL(rprec) :: orient
   REAL(rprec), ALLOCATABLE :: temp(:)
   CHARACTER(LEN=100) :: line, line2
 
@@ -365,18 +366,30 @@
   ! CHECK SIGN OF JACOBIAN (SHOULD BE SAME AS SIGNGS)
   m = 1
   mj = m+joff
+  ! An asymmetric boundary has been rotated in the poloidal angle above, to
+  ! put it into the representation with RBS(m=1) = ZBC(m=1). The product
+  ! rtest*ztest is not invariant under that rotation, which can leave it at
+  ! zero for a boundary that does need flipping. The m=1 determinant is.
   rtest = SUM(rbcc(1:ntor1,mj))
   ztest = SUM(zbsc(1:ntor1,mj))
-  lflip=(rtest*ztest .lt. zero)
+  orient = rtest*ztest
+  IF (lasym) THEN
+     orient = orient - SUM(rbsc(1:ntor1,mj))*SUM(zbcc(1:ntor1,mj))
+  END IF
+  lflip=(orient .lt. zero)
   signgs = -1.0_dp
   IF (lflip) then
-     ! (rtest*ztest < 0) means that rtest and ztest have different signs
+     ! a negative m=1 determinant means the boundary is traversed the other way
      CALL flip_theta(rmn_bdy, zmn_bdy)
   end if
 
   rtest = SUM(rbcc(1:ntor1,mj))
   ztest = SUM(zbsc(1:ntor1,mj))
-  if (rtest*ztest .lt. zero) then
+  orient = rtest*ztest
+  IF (lasym) THEN
+     orient = orient - SUM(rbsc(1:ntor1,mj))*SUM(zbcc(1:ntor1,mj))
+  END IF
+  if (orient .lt. zero) then
     stop "flip_theta did not fix it!"
   end if
 


### PR DESCRIPTION
Fixes #27.

The orientation test runs on a boundary that has already been rotated in the poloidal angle when `lasym` is set, and `rtest*ztest` is not invariant under that rotation. The m=1 determinant is, and it reduces to `rtest*ztest` for a stellarator-symmetric boundary, where `rbsc` and `zbcc` are zero, so the symmetric path keeps the criterion it had.

The rotation itself aims at RBS(m=1) = ZBC(m=1) for the boundary as read, and `flip_theta` then negates ZBC(m=1) but not RBS(m=1), so a boundary that is flipped left the representation again while the m=1 constraint went on holding the interior to it. The second commit takes the m=1 determinant before the rotation and gives a boundary that will be flipped the angle `-ATAN2(rbs(0,1) + zbc(0,1), zbs(0,1) - rbc(0,1))`, for which the representation holds after the flip. A boundary that is not flipped takes the angle it took before.

Checked with the boundary of `input.up_down_asym_current` written with theta -> theta0 - theta and with theta -> theta + theta0, which leaves the surface where it is. Each cell is iterations and the largest deviation of `iotaf` from the run on the boundary as given:

| boundary | master | first commit | both commits |
| --- | --- | --- | --- |
| theta -> -theta | 1543, 2.8e-3 | 1543, 2.8e-3 | 1310, 1.7e-10 |
| theta -> 60 - theta | 1543, 2.8e-3 | 1543, 2.8e-3 | 1310, 1.2e-9 |
| theta -> 120 - theta | no convergence, fsqr 2.1e-2 after 2000 | 1543, 2.8e-3 | 1310, 7.5e-10 |
| theta -> 150 - theta | no convergence, fsqr 2.1e-2 after 2000 | 1543, 2.8e-3 | 1310, 5.4e-10 |
| theta -> 180 - theta | no convergence, fsqr 2.1e-2 after 2000 | 1543, 2.8e-3 | 1310, 3.0e-10 |
| theta -> 240 - theta | 1543, 2.8e-3 | 1543, 2.8e-3 | 1310, 7.2e-10 |
| theta -> 300 - theta | no convergence, fsqr 2.1e-2 after 2000 | 1543, 2.8e-3 | 1310, 6.0e-10 |
| theta -> theta + 90, + 180, + 270 | 1310, at most 1.1e-9 | the same | the same |

The run on the boundary as given takes 1310 iterations. The 2.8e-3 does not fall with resolution: at ns = 33 it is 1.0e-3 for mpol = 5 and 6.3e-4 for mpol = 12.

`input.up_down_asym_current` itself gives the same wout in every variable with and without the two commits, and a stellarator-symmetric run enters neither branch.

PARVMEC forms the rotation angle with `ABS(rbc(0,1)) + ABS(zbs(0,1))` in the denominator and has the same two defects in a different set of boundaries; ORNL-Fusion/PARVMEC#93 is the corresponding change there. VMEC++ chooses the angle by the determinant already (`boundaries.cc`), and gives 1311 iterations and `iotaf` within 7.9e-10 for all ten boundaries.
